### PR TITLE
fixed animations using reversable transitions with sequential animations

### DIFF
--- a/LayOnHands.qml
+++ b/LayOnHands.qml
@@ -1,32 +1,26 @@
 import QtQuick 2.0
 
-Rectangle {
-
-    height: spell.height
-    width: spell.width
-
-    SpellInfo {
-        id: spell
-        spellName: "Lay on Hands"
-        details: "
-            <b>Standard Action</b><br>
-            touch<br>
-            Duration: Instant<br>
-            <b>Effect:</b> Apply heal from the pool.  Cure disease/poison with 5 points<br>
-            <b>The full text:</b><br>
-            Your blessed touch can heal wounds. You have a pool of healing power that replenishes when you take a long rest. With that pool, you can restore a total number of hit points equal to your paladin level × 5.
-            As an action, you can touch a creature and draw power from the pool to restore a number of hit points to that creature, up to the maximum amount remaining in your pool.
-            Alternatively, you can expend 5 hit points from your pool of healing to cure the target of one disease or neutralize one poison affecting it. You can cure multiple diseases and neutralize multiple poisons with a single use of Lay on Hands, expending hit points separately for each one.
-            This feature has no effect on undead and constructs.
-            "
-        statusTracker.children:
-            AdjustableNumber {
-                id: pool
-                minNumber: 0
-                maxNumber: 15
-                z:4
-            }
-    }
-
-
+SpellInfo {
+    id: spell
+    spellName: "Lay on Hands"
+    details: "
+        <b>Standard Action</b><br>
+        touch<br>
+        Duration: Instant<br>
+        <b>Effect:</b> Apply heal from the pool.  Cure disease/poison with 5 points<br>
+        <b>The full text:</b><br>
+        Your blessed touch can heal wounds. You have a pool of healing power that replenishes when you take a long rest. With that pool, you can restore a total number of hit points equal to your paladin level × 5.
+        As an action, you can touch a creature and draw power from the pool to restore a number of hit points to that creature, up to the maximum amount remaining in your pool.
+        Alternatively, you can expend 5 hit points from your pool of healing to cure the target of one disease or neutralize one poison affecting it. You can cure multiple diseases and neutralize multiple poisons with a single use of Lay on Hands, expending hit points separately for each one.
+        This feature has no effect on undead and constructs.
+        "
+    statusTracker.children:
+        AdjustableNumber {
+            id: pool
+            minNumber: 0
+            maxNumber: 15
+            z:4
+        }
 }
+
+

--- a/SpellInfo.qml
+++ b/SpellInfo.qml
@@ -6,15 +6,43 @@ Rectangle {
     property string spellName;
     property string details;
     property bool expanded: false;
+    property int minWideness: spellTitle.width;
+    property int maxWideness: 400;
 
     property alias statusTracker: status;
 
     color: "transparent"
-    width: expanded ? 400 : spellTitle.width
-    height: expanded ? spellTitle.height + detailsBlob.height + 8 : spellTitle.height
+    width: detailsBlob.width
+    height: spellTitle.height + detailsBlob.height;
+    state: expanded ? "Expanded" : "Collapsed"
+    states: [
+        State {
+            name: "Collapsed"
+            PropertyChanges { target: detailsBlob; width: minWideness; height: 0; opacity: 0 }
+            PropertyChanges { target: detailsBackground; opacity: 0 }
+        },
+        State {
+            name: "Expanded"
+            PropertyChanges { target: detailsBlob; width: maxWideness; height: paintedHeight + padding*2; opacity: 1 }
+            PropertyChanges { target: detailsBackground; opacity: 1 }
+        }
+    ]
 
-    Behavior on height { PropertyAnimation { duration: 500 } }
-    Behavior on width { PropertyAnimation { duration: 500 } }
+    transitions:[
+        Transition {
+            from: "Collapsed"
+            to: "Expanded"
+            reversible: true
+            SequentialAnimation {
+                ParallelAnimation {
+                    PropertyAnimation { target: detailsBlob; properties: "width,height"; duration: 400 }
+                    PropertyAnimation { target: detailsBackground; property: "opacity"; duration: 300 }
+                }
+                PropertyAnimation { target: detailsBlob; properties: "opacity"; duration: 150 }
+            }
+        }
+    ]
+
     MouseArea
     {
         anchors.fill: parent
@@ -64,7 +92,7 @@ Rectangle {
         border.width: 1
         border.color: "#888888"
         visible: (opacity != 0)
-        opacity: root.expanded ? 1 : 0
+        opacity: 0
 
         anchors {
             left: parent.left
@@ -75,8 +103,9 @@ Rectangle {
         Text {
             id: detailsBlob
             visible: (opacity != 0)
-            opacity: root.expanded ? 1 : 0
-            width: root.width
+            opacity: 0
+            width: minWideness
+            height: 0
             padding: 8
 
             text: details
@@ -84,8 +113,6 @@ Rectangle {
             textFormat: Text.StyledText
 
             font.pointSize: 10
-
-            Behavior on opacity { PropertyAnimation { duration: 500 } }
         }
     }
 }

--- a/StatBlock.qml
+++ b/StatBlock.qml
@@ -89,11 +89,16 @@ Rectangle {
         ]
 
         transitions: [
-               Transition {
-                   PropertyAnimation { properties: "width,opacity"; target: proficientSkills; duration: 500}
-               }
-           ]
-
+           Transition {
+            from: "Collapsed"
+            to: "Expanded"
+            reversible: true
+                SequentialAnimation{
+                    PropertyAnimation { property: "width"; target: proficientSkills; duration: 250}
+                    PropertyAnimation { property: "opacity"; target: proficientSkills; duration: 150}
+                }
+           }
+        ]
     }
 
     function getBonus()


### PR DESCRIPTION
removed extra rectangle from layonhands to fix transparency
updated transition in statblock
fixed width and heights in spellinfo objects and created states and transtions with sequential animations to have opacity on text change after box resizing